### PR TITLE
Editted a typo in comment entity file. comment 엔티티 파일 내 오탈자를 수정했습니다.

### DIFF
--- a/src/comment/comment_table.entity.ts
+++ b/src/comment/comment_table.entity.ts
@@ -18,5 +18,5 @@ export class CommentTable extends BaseEntity
     comment_date : string;
 
     @Column({type : 'character varying'})
-    comment_comment : string;
+    comment_content : string;
 }


### PR DESCRIPTION
comment_content를 comment_comment로 잘못 쓴 부분을 수정했습니다. 